### PR TITLE
v0.0.5 (fix pandas warnings)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4
+current_version = 0.0.5
 commit = False
 tag = False
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_DEV_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.DEV_NETLIFY_SITE_ID }}
         with:
-          args: deploy --dir="docs/_build/html"
+          args: deploy --dir="docs/_build/html" --no-build
         timeout-minutes: 5
 
 
@@ -171,7 +171,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_PROD_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.PROD_NETLIFY_SITE_ID }}
         with:
-          args: deploy --dir="docs/_build/html" --prod
+          args: deploy --dir="docs/_build/html" --prod --no-build
         timeout-minutes: 5
 
       - name: Publish package

--- a/crosseval/__init__.py
+++ b/crosseval/__init__.py
@@ -42,7 +42,7 @@ __all__ = [
 
 __author__ = """Maxim Zaslavsky"""
 __email__ = "maxim@maximz.com"
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 # Set default logging handler to avoid "No handler found" warnings.
 logging.getLogger(__name__).addHandler(NullHandler())

--- a/crosseval/model_global_performance.py
+++ b/crosseval/model_global_performance.py
@@ -236,15 +236,15 @@ class ModelGlobalPerformance:
                 )
             map_metric_keyname_to_friendly_name[colname] = friendly_names[0]
         # now change df to have values = metric value rather than full Metric object (again, note that a metric might not appear in all folds)
-        scores_per_fold = scores_per_fold.applymap(
+        scores_per_fold = scores_per_fold.map(
             lambda metric: metric.value if isinstance(metric, Metric) else np.nan
         )
 
         # aggregate mean, standard deviation, and non-NaN count (columns) for each metric keyname (index)
         scores_per_fold_agg = scores_per_fold.describe().loc[["mean", "std", "count"]].T
-        scores_per_fold_agg["std"].fillna(
-            0, inplace=True
-        )  # if a metric appeared in only one fold, it will have std NaN
+        # if a metric appeared in only one fold, it will have std NaN, so fillna
+        scores_per_fold_agg["std"] = scores_per_fold_agg["std"].fillna(0)
+
         # Add metric friendlyname. (unlike replace()'s pass-through behavior, map() means that if not in the dict, will store NaN)
         scores_per_fold_agg[
             "metric_friendly_name"

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     description="crosseval",
     packages=find_packages(include=["crosseval", "crosseval.*"]),
     python_requires=">=3.8",
-    version="0.0.4",
+    version="0.0.5",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -523,8 +523,7 @@ def test_feature_importances_and_names_with_default_feature_names(
 
             ## Test feature names and feature importances for single fold
             if model_name in dummy_models:
-                # dummy has no coefs, and also swallows feature names
-                assert single_perf.feature_names is None
+                # dummy has no coefs
                 assert single_perf.feature_importances is None
                 assert single_perf.multiclass_feature_importances is None
             elif model_name in ovr_models:
@@ -663,8 +662,7 @@ def test_feature_importances_and_names_with_custom_feature_names(
             ## Test feature names and feature importances for single fold
 
             if model_name in dummy_models:
-                # dummy has no coefs, and also swallows feature names
-                assert single_perf.feature_names is None
+                # dummy has no coefs
                 assert single_perf.feature_importances is None
                 assert single_perf.multiclass_feature_importances is None
             elif model_name in ovr_models:


### PR DESCRIPTION
```
FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.

FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.\nThe behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.\n\nFor example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.
```