### PR TITLE
Add column_format="keyname" to get_model_comparison_stats (0.0.7)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.6
+current_version = 0.0.7
 commit = False
 tag = False
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.7
+
+* Add `column_format="keyname"` to `get_model_comparison_stats` (and the underlying `_get_stats`/`_full_report_scores`/`aggregated_per_fold_scores`/`global_scores`) so callers can get stable scorer-keyname columns directly instead of reverse-engineering the friendly-to-keyname map. Default `"friendly"` keeps existing column names unchanged.
+
 ## 0.0.6
 
 * Add `formatted=False` outputs for programmatic consumers of summary methods.

--- a/crosseval/__init__.py
+++ b/crosseval/__init__.py
@@ -42,7 +42,7 @@ __all__ = [
 
 __author__ = """Maxim Zaslavsky"""
 __email__ = "maxim@maximz.com"
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 # Set default logging handler to avoid "No handler found" warnings.
 logging.getLogger(__name__).addHandler(NullHandler())

--- a/crosseval/experiment_set_global_performance.py
+++ b/crosseval/experiment_set_global_performance.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Tuple, Union, Optional
+from typing import Callable, Dict, Literal, Tuple, Union, Optional
 
 import pandas as pd
 
@@ -24,6 +24,7 @@ class ExperimentSetGlobalPerformance:
         probability_scorers: Optional[Dict[str, Tuple[Callable, str, dict]]] = None,
         sort=True,
         formatted: bool = True,
+        column_format: Literal["friendly", "keyname"] = "friendly",
     ):
         """Cross-fold comparison table, one row per model.
 
@@ -31,7 +32,18 @@ class ExperimentSetGlobalPerformance:
         ``"mean +/- std (in N folds)"`` strings and globals as 3-decimal strings,
         for human display. ``formatted=False`` returns raw floats, suitable for
         programmatic sorting or downstream aggregation.
+
+        ``column_format`` controls the metric column names: ``"friendly"`` (default)
+        uses friendly metric names (e.g. ``"MCC per fold"``); ``"keyname"`` uses the
+        stable scorer keynames instead (e.g. ``"mcc per fold"``), so consumers get
+        machine keys directly without reverse-engineering the friendly-to-keyname map.
+        The per-fold/global and with/without-abstention suffixes, the ``sample_size``
+        column, and the other non-metric summary columns are unchanged in both modes.
         """
+        if column_format not in ("friendly", "keyname"):
+            raise ValueError(
+                f"column_format must be 'friendly' or 'keyname', not {column_format!r}"
+            )
         if len(self.model_global_performances) == 0:
             # Edge case: empty
             return pd.DataFrame()
@@ -43,6 +55,7 @@ class ExperimentSetGlobalPerformance:
                     label_scorers=label_scorers,
                     probability_scorers=probability_scorers,
                     formatted=formatted,
+                    column_format=column_format,
                 )
                 for model_name, model_global_performance in self.model_global_performances.items()
             },

--- a/crosseval/model_global_performance.py
+++ b/crosseval/model_global_performance.py
@@ -10,6 +10,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Tuple,
     Union,
     Optional,
@@ -339,14 +340,18 @@ class ModelGlobalPerformance:
         label_scorers: Optional[Dict[str, Tuple[Callable, str, dict]]] = None,
         probability_scorers: Optional[Dict[str, Tuple[Callable, str, dict]]] = None,
         formatted: bool = True,
+        column_format: Literal["friendly", "keyname"] = "friendly",
     ) -> Dict[str, Union[str, float]]:
-        """return dict mapping friendly-metric-name to per-fold aggregate.
+        """return dict mapping metric name to per-fold aggregate.
 
         When ``formatted`` is True (default), values are ``"mean +/- std (in N folds)"``
         strings for human display. When False, values are the raw mean across folds as
         a float — useful for programmatic downstream use where the caller wants to do
         its own formatting or comparison. NaN-folds are dropped from the mean (matching
         the formatted variant's count semantics).
+
+        ``column_format`` controls the dict keys: ``"friendly"`` (default) uses each
+        metric's friendly name; ``"keyname"`` uses its stable scorer keyname.
         """
         raw_metrics_per_fold = self._raw_metrics_per_fold(
             with_abstention=with_abstention,
@@ -403,19 +408,25 @@ class ModelGlobalPerformance:
         if scores_per_fold_agg["metric_friendly_name"].duplicated().any():
             raise ValueError("Some metrics had duplicate friendly names")
 
+        # The index is the metric keyname; choose keyname or friendly name for the key.
+        def _key(keyname, row):
+            return (
+                keyname if column_format == "keyname" else row["metric_friendly_name"]
+            )
+
         if not formatted:
             # Raw float means for programmatic consumers.
             return {
-                row["metric_friendly_name"]: float(row["mean"])
-                for _, row in scores_per_fold_agg.iterrows()
+                _key(keyname, row): float(row["mean"])
+                for keyname, row in scores_per_fold_agg.iterrows()
             }
 
         # summarize a range of scores into strings: mean plus-minus one standard deviation (68% interval if normally distributed).
         return {
-            row[
-                "metric_friendly_name"
-            ]: f"""{row["mean"]:0.3f} +/- {row["std"]:0.3f} (in {row["count"]:n} folds)"""
-            for _, row in scores_per_fold_agg.iterrows()
+            _key(
+                keyname, row
+            ): f"""{row["mean"]:0.3f} +/- {row["std"]:0.3f} (in {row["count"]:n} folds)"""
+            for keyname, row in scores_per_fold_agg.iterrows()
         }
 
     @staticmethod
@@ -787,6 +798,7 @@ class ModelGlobalPerformance:
         label_scorers: Optional[Dict[str, Tuple[Callable, str, dict]]] = None,
         probability_scorers: Optional[Dict[str, Tuple[Callable, str, dict]]] = None,
         formatted: bool = True,
+        column_format: Literal["friendly", "keyname"] = "friendly",
     ):
         scores = {
             "per_fold": self.aggregated_per_fold_scores(
@@ -794,11 +806,13 @@ class ModelGlobalPerformance:
                 label_scorers=label_scorers,
                 probability_scorers=probability_scorers,
                 formatted=formatted,
+                column_format=column_format,
             ),
             "global": self.global_scores(
                 with_abstention=False,
                 label_scorers=label_scorers,
                 formatted=formatted,
+                column_format=column_format,
             ),
         }
         if self.has_abstentions:
@@ -808,11 +822,13 @@ class ModelGlobalPerformance:
                 label_scorers=label_scorers,
                 probability_scorers=probability_scorers,
                 formatted=formatted,
+                column_format=column_format,
             )
             scores["global_with_abstention"] = self.global_scores(
                 with_abstention=True,
                 label_scorers=label_scorers,
                 formatted=formatted,
+                column_format=column_format,
             )
         return scores
 
@@ -884,6 +900,7 @@ class ModelGlobalPerformance:
         label_scorers: Optional[Dict[str, Tuple[Callable, str, dict]]] = None,
         probability_scorers: Optional[Dict[str, Tuple[Callable, str, dict]]] = None,
         formatted: bool = True,
+        column_format: Literal["friendly", "keyname"] = "friendly",
     ) -> dict:
         """Calculate global scores with or without abstention. Global scores should not include probabilistic scores.
 
@@ -894,6 +911,11 @@ class ModelGlobalPerformance:
         compatibility with callers that pass the same scorer bundle to per-fold and
         global summaries, but probability-based metrics are intentionally ignored
         for global scores.
+
+        ``column_format`` controls the dict keys: ``"friendly"`` (default) uses each
+        metric's friendly name; ``"keyname"`` uses its stable scorer keyname (and the
+        snake_case keys ``"abstention_rate"``, ``"abstention_label"``,
+        ``"global_evaluation_column_name"`` for the non-metric entries).
         """
         scores = compute_classification_scores(
             y_true=self.cv_y_true_with_abstention
@@ -910,35 +932,46 @@ class ModelGlobalPerformance:
             label_scorers=label_scorers,
             probability_scorers={},
         )
-        if formatted:
-            scores_out = [
-                (metric.friendly_name, f"{metric.value:0.3f}")
-                for metric_keyname, metric in scores.items()
-            ]
-        else:
-            scores_out = [
-                (metric.friendly_name, float(metric.value))
-                for metric_keyname, metric in scores.items()
-            ]
-        # confirm all metric friendly names are unique
-        all_metric_friendly_names = [v[0] for v in scores_out]
-        if len(set(all_metric_friendly_names)) != len(all_metric_friendly_names):
-            raise ValueError("Metric friendly names are not unique")
+
+        # Key by metric keyname or friendly name depending on column_format.
+        def _key(metric_keyname, metric):
+            return (
+                metric_keyname if column_format == "keyname" else metric.friendly_name
+            )
+
+        scores_out = [
+            (
+                _key(metric_keyname, metric),
+                f"{metric.value:0.3f}" if formatted else float(metric.value),
+            )
+            for metric_keyname, metric in scores.items()
+        ]
+        # confirm all metric names are unique
+        all_metric_names = [v[0] for v in scores_out]
+        if len(set(all_metric_names)) != len(all_metric_names):
+            raise ValueError("Metric names are not unique")
 
         # then convert to dict
         scores_out = dict(scores_out)
 
+        keyname_mode = column_format == "keyname"
         if with_abstention:
-            scores_out["Unknown/abstention proportion"] = (
+            scores_out[
+                "abstention_rate" if keyname_mode else "Unknown/abstention proportion"
+            ] = (
                 f"{self.abstention_proportion:0.3f}"
                 if formatted
                 else float(self.abstention_proportion)
             )
-            scores_out["Abstention label"] = self.abstain_label
+            scores_out["abstention_label" if keyname_mode else "Abstention label"] = (
+                self.abstain_label
+            )
 
         if self.global_evaluation_column_name is not None:
             scores_out[
-                "Global evaluation column name"
+                "global_evaluation_column_name"
+                if keyname_mode
+                else "Global evaluation column name"
             ] = self.global_evaluation_column_name
 
         return scores_out
@@ -948,12 +981,14 @@ class ModelGlobalPerformance:
         label_scorers: Optional[Dict[str, Tuple[Callable, str, dict]]] = None,
         probability_scorers: Optional[Dict[str, Tuple[Callable, str, dict]]] = None,
         formatted: bool = True,
+        column_format: Literal["friendly", "keyname"] = "friendly",
     ):
         """Get overall stats for table"""
         scores = self._full_report_scores(
             label_scorers=label_scorers,
             probability_scorers=probability_scorers,
             formatted=formatted,
+            column_format=column_format,
         )
 
         # Combine all scores into single dictionary.

--- a/crosseval/model_global_performance.py
+++ b/crosseval/model_global_performance.py
@@ -963,9 +963,9 @@ class ModelGlobalPerformance:
                 if formatted
                 else float(self.abstention_proportion)
             )
-            scores_out["abstention_label" if keyname_mode else "Abstention label"] = (
-                self.abstain_label
-            )
+            scores_out[
+                "abstention_label" if keyname_mode else "Abstention label"
+            ] = self.abstain_label
 
         if self.global_evaluation_column_name is not None:
             scores_out[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "crosseval"
-version = "0.0.6"
+version = "0.0.7"
 description = "Cross-validation summary tools for classifier evaluation."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -100,10 +100,12 @@ weighted avg       1.00      1.00      1.00        10
     )
 
     experiment_set_global_performance.export_all_models(
-        func_generate_classification_report_fname=lambda model_name: tmp_path
-        / f"{model_name}.classification_report.txt",
-        func_generate_confusion_matrix_fname=lambda model_name: tmp_path
-        / f"{model_name}.confusion_matrix.png",
+        func_generate_classification_report_fname=lambda model_name: (
+            tmp_path / f"{model_name}.classification_report.txt"
+        ),
+        func_generate_confusion_matrix_fname=lambda model_name: (
+            tmp_path / f"{model_name}.confusion_matrix.png"
+        ),
         confusion_matrix_figsize=(4, 4),
         dpi=72,
     )
@@ -254,10 +256,12 @@ weighted avg       1.00      0.83      0.90        12
     )
 
     experiment_set_global_performance.export_all_models(
-        func_generate_classification_report_fname=lambda model_name: tmp_path
-        / f"{model_name}.classification_report.txt",
-        func_generate_confusion_matrix_fname=lambda model_name: tmp_path
-        / f"{model_name}.confusion_matrix.png",
+        func_generate_classification_report_fname=lambda model_name: (
+            tmp_path / f"{model_name}.classification_report.txt"
+        ),
+        func_generate_confusion_matrix_fname=lambda model_name: (
+            tmp_path / f"{model_name}.confusion_matrix.png"
+        ),
         dpi=72,
     )
 
@@ -390,10 +394,12 @@ weighted avg       1.00      0.71      0.81        14
     )
 
     experiment_set_global_performance.export_all_models(
-        func_generate_classification_report_fname=lambda model_name: tmp_path
-        / f"{model_name}.classification_report.txt",
-        func_generate_confusion_matrix_fname=lambda model_name: tmp_path
-        / f"{model_name}.confusion_matrix.png",
+        func_generate_classification_report_fname=lambda model_name: (
+            tmp_path / f"{model_name}.classification_report.txt"
+        ),
+        func_generate_confusion_matrix_fname=lambda model_name: (
+            tmp_path / f"{model_name}.confusion_matrix.png"
+        ),
         dpi=72,
     )
 

--- a/tests/test_model_global_performance.py
+++ b/tests/test_model_global_performance.py
@@ -117,6 +117,104 @@ def test_model_comparison_stats_formatted_false_returns_numeric_scores():
     assert stats.loc["model", "Accuracy global"] == 1.0
 
 
+def test_model_comparison_stats_keyname_columns_use_metric_keynames():
+    # Two folds with an abstention in one fold, so the with-abstention columns appear.
+    perf = crosseval.ModelGlobalPerformance(
+        model_name="model",
+        per_fold_outputs={
+            0: crosseval.ModelSingleFoldPerformance(
+                model_name="model",
+                fold_id=0,
+                y_true=np.array(["a", "b"]),
+                y_pred=np.array(["a", "b"]),
+                class_names=np.array(["a", "b"]),
+                fold_label_train="train",
+                fold_label_test="test",
+                test_abstentions=np.array(["a"]),
+            ),
+            1: crosseval.ModelSingleFoldPerformance(
+                model_name="model",
+                fold_id=1,
+                y_true=np.array(["a", "b"]),
+                y_pred=np.array(["a", "b"]),
+                class_names=np.array(["a", "b"]),
+                fold_label_train="train",
+                fold_label_test="test",
+            ),
+        },
+        abstain_label="Unknown",
+    )
+    experiment = crosseval.ExperimentSetGlobalPerformance({"model": perf})
+
+    label_scorers = {
+        "accuracy": (lambda y_true, y_pred, sample_weight=None: 1.0, "Accuracy", {}),
+        "mcc": (lambda y_true, y_pred, sample_weight=None: 0.5, "MCC", {}),
+    }
+
+    friendly = experiment.get_model_comparison_stats(
+        label_scorers=label_scorers,
+        probability_scorers={},
+        formatted=False,
+        sort=False,
+    )
+    keyname = experiment.get_model_comparison_stats(
+        label_scorers=label_scorers,
+        probability_scorers={},
+        formatted=False,
+        sort=False,
+        column_format="keyname",
+    )
+
+    # Default friendly columns are unchanged: friendly metric names + suffixes.
+    assert {
+        "Accuracy per fold",
+        "MCC per fold",
+        "Accuracy global",
+        "MCC global",
+        "Accuracy per fold with abstention",
+        "MCC per fold with abstention",
+        "Accuracy global with abstention",
+        "MCC global with abstention",
+    }.issubset(friendly.columns)
+
+    # The keyname metric columns are exactly the metric keynames plus suffixes,
+    # including the with_abstention variants.
+    expected_keyname_metric_cols = {
+        "accuracy per fold",
+        "mcc per fold",
+        "accuracy global",
+        "mcc global",
+        "accuracy per fold with abstention",
+        "mcc per fold with abstention",
+        "accuracy global with abstention",
+        "mcc global with abstention",
+    }
+    assert expected_keyname_metric_cols.issubset(keyname.columns)
+
+    # No friendly metric string leaks through into the keyname columns.
+    for friendly_name in ("Accuracy", "MCC", "Unknown/abstention proportion"):
+        assert not any(friendly_name in col for col in keyname.columns)
+
+    # Non-metric summary columns and the abstention/non-abstention distinction are
+    # preserved identically in both modes.
+    for col in (
+        "sample_size",
+        "n_abstentions",
+        "sample_size including abstentions",
+        "abstention_rate",
+        "missing_classes",
+    ):
+        assert col in keyname.columns
+        assert col in friendly.columns
+
+    # Values match between the two column formats (same data, different keys).
+    assert keyname.loc["model", "mcc per fold"] == friendly.loc["model", "MCC per fold"]
+    assert (
+        keyname.loc["model", "mcc global with abstention"]
+        == friendly.loc["model", "MCC global with abstention"]
+    )
+
+
 def test_aggregated_per_fold_scores_supports_distinct_scorer_arguments():
     perf = crosseval.ModelGlobalPerformance(
         model_name="model",

--- a/uv.lock
+++ b/uv.lock
@@ -967,7 +967,7 @@ toml = [
 
 [[package]]
 name = "crosseval"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary


`ExperimentSetGlobalPerformance.get_model_comparison_stats(...)` returns a comparison table whose metric columns use friendly names (`"MCC per fold"`, `"MCC global"`, ...) even when `formatted=False`. Consumers wanting stable machine keys had to reverse-engineer the friendly→keyname map themselves: iterate `ModelSingleFoldPerformance.scores(...)`, read each `metric.friendly_name → keyname`, then string-strip the `" per fold"` / `" global"` / `"... with abstention"` suffixes. Brittle.

This adds a `column_format` argument so callers get keyname columns directly:

```python
stats = experiment.get_model_comparison_stats(formatted=False, column_format="keyname")
# columns: "mcc per fold", "mcc global", "mcc per fold with abstention", "mcc global with abstention", ...
```

## API

- `column_format="friendly"` (default) — unchanged; friendly-name columns like `"MCC per fold"`.
- `column_format="keyname"` — metric columns use stable scorer keynames (e.g. `"mcc per fold"`).

Orthogonal to `formatted`. Threaded down through `_get_stats` → `_full_report_scores` → `aggregated_per_fold_scores` / `global_scores`, so the same arg is available on those lower-level methods too. Invalid values raise `ValueError`.

## Backward compatibility

- Default behavior is 100% unchanged (`formatted=True` and `formatted=False` output identical to before unless `column_format="keyname"` is requested).
- The per-fold/global and with/without-abstention suffixes, the `sample_size` column, and the abstention vs non-abstention column distinction are preserved in both modes.
- In keyname mode, the non-metric entries map to snake_case keys (`abstention_rate`, `abstention_label`, `global_evaluation_column_name`).

## Tests

Added a unit test asserting keyname columns are exactly the metric keynames (no friendly strings leak through), including the `with_abstention` variants, and that values match across both formats.

## Other

- Bumped version 0.0.6 → 0.0.7; updated CHANGELOG.
- Second commit applies ruff-format to pre-existing formatting drift in a few files (no behavior change).
